### PR TITLE
Ignore when unable to delete lambda edge replicated function

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,12 @@ class PrunePlugin {
         Qualifier: version
       };
       
-      return this.provider.request('Lambda', 'deleteFunction', params);
+      return this.provider.request('Lambda', 'deleteFunction', params)
+      .catch(e => {
+        //ignore if trying to delete replicated lambda edge function
+        if (e.statusCode === 400 && e.message.startsWith('Lambda was unable to delete') && e.message.endsWith('because it is a replicated function.')) this.serverless.cli.log(`Prune: Unable deleting replicated edge function ${functionName} v${version}...`);
+        else throw e;
+      });
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -124,7 +124,8 @@ class PrunePlugin {
         Qualifier: version
       };
       
-      return this.provider.request('Lambda', 'deleteFunction', params)
+      return BbPromise.resolve()
+      .then(() => this.provider.request('Lambda', 'deleteFunction', params))
       .catch(e => {
         //ignore if trying to delete replicated lambda edge function
         if (e.statusCode === 400 && e.message.startsWith('Lambda was unable to delete') && e.message.endsWith('because it is a replicated function.')) this.serverless.cli.log(`Prune: Unable deleting replicated edge function ${functionName} v${version}...`);


### PR DESCRIPTION
Currently it isn’t able to delete replicated lambda edge functions so this fix make the plugin continue to work without crashing.