### PR TITLE
Fix for resolving variable references

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ class Prune {
   }
 
   postDeploy() {
+    this.pluginCustom = this.loadCustom(this.serverless.service.custom);
 
     if (this.options.noDeploy === true) {
       return BbPromise.resolve();


### PR DESCRIPTION
When I use a variable in a custom property of serverless.yml, its value was not resolved.
For example, (this environment variable could not use.)
```
custom:
  prune:
    automatic: true
    number: ${env:ENV_PRUNE_NUMBER}
```

Since the variable is not resolved in the constructor, it must be acquired by hook side. So I Fixed.
( FYI: https://forum.serverless.com/t/serverless-plugin-resolving-variable-references/2233 )