### PR TITLE
Fix sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ class Prune {
       .map(f => f.Version)
       .filter(v => v !== '$LATEST') //skip $LATEST
       .filter(v => aliasedVersion.indexOf(v) === -1) //skip aliased versions
-      .sort((a, b) => parseInt(b) - parseInt(a))
+      .sort((a, b) => parseInt(a) === parseInt(b) ? 0 : parseInt(a) > parseInt(b) ? -1 : 1)
       .slice(this.getNumber());
 
     return deletionCandidates;


### PR DESCRIPTION
Javascript array sorting can be a bit unpredictable unless a function that always returns 0, -1 or 1 is used.

Proof it sorts correctly:
![image](https://user-images.githubusercontent.com/447559/61457785-f7271900-a960-11e9-94da-e21ff5f6ebf1.png)

Hopefully goes some way toward addressing https://github.com/claygregory/serverless-prune-plugin/issues/14