### PR TITLE
Feature: Prune Lambda Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ custom:
 
 To run automatically, the `automatic` property of `prune` must be set to `true` and the `number` of versions to keep must be specified.
 
+### Layers
+
+This plugin can also prune Lambda Layers in the same manner that it prunes functions. You can specify a Lambda Layer, or add the flag, `includeLayers`:
+
+```yaml
+custom:
+  prune:
+    automatic: true
+    includeLayers: true
+    number: 3
+```
 
 ### Dry Run
 

--- a/index.js
+++ b/index.js
@@ -76,6 +76,14 @@ class Prune {
         pluginCustom.automatic = custom.prune.automatic;
       }
 
+      if (custom.prune.includeLayers != null && typeof custom.prune.includeLayers === 'boolean') {
+        pluginCustom.includeLayers = custom.prune.includeLayers;
+      }
+
+      if (custom.prune.layer != null) {
+        pluginCustom.layer = custom.prune.layer;
+      }
+
     }
 
     return pluginCustom;

--- a/index.js
+++ b/index.js
@@ -80,10 +80,6 @@ class Prune {
         pluginCustom.includeLayers = custom.prune.includeLayers;
       }
 
-      if (custom.prune.layer != null) {
-        pluginCustom.layer = custom.prune.layer;
-      }
-
     }
 
     return pluginCustom;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "1.3.3",
   "description": "Serverless plugin to delete old versions of deployed functions from AWS",
   "author": "Clay Gregory <clay@claygregory.com> (https://claygregory.com/)",
-  "keywords": ["serverless", "serverless-plugin", "aws", "aws-lambda", "lambda"],
+  "keywords": [
+    "serverless",
+    "serverless-plugin",
+    "aws",
+    "aws-lambda",
+    "lambda"
+  ],
   "repository": "claygregory/serverless-prune-plugin",
   "homepage": "https://github.com/claygregory/serverless-prune-plugin",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -393,22 +393,6 @@ describe('Prune', function() {
 
     });
 
-    it('should not delete layers that do not exist', function () {
-
-      const serverless = createMockServerlessWithLayers(['LayerA']);
-      const plugin = new PrunePlugin(serverless, { number: 2 });
-
-      plugin.provider.request.withArgs('Lambda', 'listLayerVersions', sinon.match.any)
-        .returns(createLayerVersionsResponse([1, 2, 3, 4, 5]));
-
-      return plugin.pruneLayers().then(() => {
-        sinon.assert.calledWith(plugin.provider.request, 'Lambda', 'deleteLayerVersion', versionMatcher('1'));
-        sinon.assert.calledWith(plugin.provider.request, 'Lambda', 'deleteLayerVersion', versionMatcher('2'));
-        sinon.assert.calledWith(plugin.provider.request, 'Lambda', 'deleteLayerVersion', versionMatcher('3'));
-      });
-
-    });
-
     it('should keep requested number of version', function () {
 
       const serverless = createMockServerlessWithLayers(['LayerA'], {

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,7 @@ describe('Prune', function() {
       }
     );
 
-    return Object.assign(serverless, {...withLayers});
+    return Object.assign(serverless, withLayers);
   }
 
   function createMockServerless(functions, serviceCustom) {
@@ -73,7 +73,7 @@ describe('Prune', function() {
     resp.LayerVersions = versions.map(v => {
       return {
         Version: '' + v
-      }
+      };
     });
 
     return Promise.resolve(resp);
@@ -494,7 +494,7 @@ describe('Prune', function() {
       });
 
     });
-  })
+  });
 
   describe('postDeploy', function() {
 
@@ -536,7 +536,7 @@ describe('Prune', function() {
       return plugin.postDeploy().then(() => {
         sinon.assert.notCalled(plugin.pruneLayers);
       });
-    })
+    });
 
   });
 


### PR DESCRIPTION
This uses the same `number` to prune with as functions. Unit tests are included, as well.

### Additional Options
- `includeLayers` - `boolean` flag which specifies to include the pruning of Lambda layers (must be specified in order to prune layers)
- `layer` - `string` in which to prune a specific Lambda layer (similar to that of `function` or `-f` option)

### AWS Endpoint API Sources
- `listLayerVersions` - https://docs.aws.amazon.com/lambda/latest/dg/API_ListLayerVersions.html
- `deleteLayerVersion` - https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteLayerVersion.html