### PR TITLE
Fix. Ignore when unable to delete lambda edge replicated function new error wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ class Prune {
     return this.makeLambdaRequest('listAliases', params, r => r.Aliases)
       .catch(e => {
         //ignore if function not deployed
-        if (e.statusCode === 404) return [];
+        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
         else throw e;
       });
   }
@@ -243,7 +243,7 @@ class Prune {
     return this.makeLambdaRequest('listVersionsByFunction', params, r => r.Versions)
       .catch(e => {
         //ignore if function not deployed
-        if (e.statusCode === 404) return [];
+        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
         else throw e;
       });
   }
@@ -256,7 +256,7 @@ class Prune {
     return this.makeLambdaRequest('listLayerVersions', params, r => r.LayerVersions)
       .catch(e => {
         // ignore if layer not deployed
-        if (e.statusCode === 404) return [];
+        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
         else throw e;
       });
     

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class Prune {
         .then(() => this.provider.request('Lambda', 'deleteFunction', params))
         .catch(e => {
           //ignore if trying to delete replicated lambda edge function
-          if (e.statusCode === 400 && e.message.startsWith('Lambda was unable to delete') && e.message.indexOf('because it is a replicated function.') > -1) this.serverless.cli.log(`Prune: Unable to delete replicated edge function ${functionName} v${version}...`);
+          if ((e.statusCode === 400 || e.providerError.statusCode === 400) && e.message.startsWith('Lambda was unable to delete') && e.message.indexOf('because it is a replicated function.') > -1) this.serverless.cli.log(`Prune: Unable to delete replicated edge function ${functionName} v${version}...`);
           else throw e;
         });
     });

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class Prune {
         .then(() => this.provider.request('Lambda', 'deleteFunction', params))
         .catch(e => {
           //ignore if trying to delete replicated lambda edge function
-          if ((e.statusCode === 400 || e.providerError.statusCode === 400) && e.message.startsWith('Lambda was unable to delete') && e.message.indexOf('because it is a replicated function.') > -1) this.serverless.cli.log(`Prune: Unable to delete replicated edge function ${functionName} v${version}...`);
+          if (e.providerError.statusCode === 400 && e.providerError.message.startsWith('Lambda was unable to delete') && e.providerError.message.indexOf('because it is a replicated function.') > -1) this.serverless.cli.log(`Prune: Unable to delete replicated edge function ${functionName} v${version}...`);
           else throw e;
         });
     });
@@ -230,7 +230,7 @@ class Prune {
     return this.makeLambdaRequest('listAliases', params, r => r.Aliases)
       .catch(e => {
         //ignore if function not deployed
-        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
+        if (e.providerError.statusCode === 404) return [];
         else throw e;
       });
   }
@@ -243,7 +243,7 @@ class Prune {
     return this.makeLambdaRequest('listVersionsByFunction', params, r => r.Versions)
       .catch(e => {
         //ignore if function not deployed
-        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
+        if (e.providerError.statusCode === 404) return [];
         else throw e;
       });
   }
@@ -256,7 +256,7 @@ class Prune {
     return this.makeLambdaRequest('listLayerVersions', params, r => r.LayerVersions)
       .catch(e => {
         // ignore if layer not deployed
-        if (e.statusCode === 404 || e.providerError.statusCode === 404) return [];
+        if (e.providerError.statusCode === 404) return [];
         else throw e;
       });
     

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,7 @@ describe('Prune', function() {
     it('should ignore failure while deleting lambda edge function', function(done) {
 
       plugin.provider.request.withArgs('Lambda', 'deleteFunction', sinon.match.any)
-        .rejects({ statusCode: 400, message: 'Lambda was unable to delete arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME:FUNCTION_VERSION because it is a replicated function. Please see our documentation for Deleting Lambda@Edge Functions and Replicas.' });
+        .rejects({ providerError: { statusCode: 400, message: 'Lambda was unable to delete arn:aws:lambda:REGION:ACCOUNT_ID:function:FUNCTION_NAME:FUNCTION_VERSION because it is a replicated function. Please see our documentation for Deleting Lambda@Edge Functions and Replicas.' }});
 
       plugin.deleteVersionsForFunction('MyEdgeFunction', [1])
         .then(() => done())
@@ -199,7 +199,7 @@ describe('Prune', function() {
     it('should fail when error while deleting regular lambda function', function(done) {
 
       plugin.provider.request.withArgs('Lambda', 'deleteFunction', sinon.match.any)
-        .rejects({ statusCode: 400, message: 'Some Error' });
+        .rejects({ providerError: { statusCode: 400, message: 'Some Error' }});
 
       plugin.deleteVersionsForFunction('MyFunction', [1])
         .then(() => done(new Error('should fail')))
@@ -317,10 +317,10 @@ describe('Prune', function() {
       const plugin = new PrunePlugin(serverless, { number: 1 });
       
       plugin.provider.request.withArgs('Lambda', 'listVersionsByFunction', functionMatcher('service-FunctionA'))
-        .rejects({ statusCode: 404 });
+        .rejects({ providerError: { statusCode: 404 }});
 
       plugin.provider.request.withArgs('Lambda', 'listAliases', functionMatcher('service-FunctionA'))
-        .rejects({ statusCode: 404 });
+        .rejects({ providerError: { statusCode: 404 }});
 
       plugin.provider.request.withArgs('Lambda', 'listVersionsByFunction', functionMatcher('service-FunctionB'))
         .returns(createVersionsResponse([1, 2, 3]));
@@ -436,7 +436,7 @@ describe('Prune', function() {
       const plugin = new PrunePlugin(serverless, { number: 1, includeLayers: true });
 
       plugin.provider.request.withArgs('Lambda', 'listLayerVersions', layerMatcher('layer-LayerA'))
-        .rejects({ statusCode: 404 });
+        .rejects({ providerError: { statusCode: 404 }});
 
       plugin.provider.request.withArgs('Lambda', 'listLayerVersions', layerMatcher('layer-LayerB'))
         .returns(createLayerVersionsResponse([1, 2, 3]));


### PR DESCRIPTION
this is an addition to this pr:
https://github.com/claygregory/serverless-prune-plugin/pull/5

I have such error:

Serverless Error ---------------------------------------
 
  Lambda was unable to delete arn:aws:lambda:us-east-1:11111:function:xxxxxxx:6 because it is a replicated function. Please see our documentation for Deleting Lambda@Edge Functions and Replicas.
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              10.15.3
     Framework Version:         1.63.0
     Plugin Version:            3.3.0
     SDK Version:               2.3.0
     Components Core Version:   1.1.2
     Components CLI Version:    1.4.0
in my case for some reasons in this place:
https://github.com/claygregory/serverless-prune-plugin/blob/master/index.js#L219

I see that e.statusCode === undefined
https://monosnap.com/file/TxvBqFKjyGHjNBxghC2aHh9IompOGi

perhaps the serverless wrapped the error a little differently.
and for get code need use such path - e.providerError.statusCode