### PR TITLE
Register `serverless` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "mocha": "^4.0.0",
     "mocha-lcov-reporter": "^1.2.0",
     "sinon": "^4.0.1"
+  },
+  "peerDependencies": {
+    "serverless": "1 || 2"
   }
 }


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_
