### PR TITLE
Allow pruning all versions if explicitly configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ custom:
 ```
 
 To run automatically, the `automatic` property of `prune` must be set to `true` and the `number` of versions to keep must be specified.
+It is possible to set `number` to `0`. In this case, the plugin will delete all the function versions (except $LATEST); this is useful when disabling function versioning for an already-deployed stack.
 
 ### Layers
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ class Prune {
       return BbPromise.resolve();
     }
 
-    if (this.pluginCustom.automatic && this.pluginCustom.number >= 1) {
+    if (this.pluginCustom.automatic && 
+      this.pluginCustom.number !== undefined && this.pluginCustom.number >= 0) {
       this.serverless.cli.log('Prune: Running post-deployment pruning');
       
       if(this.pluginCustom.includeLayers) {

--- a/test/index.js
+++ b/test/index.js
@@ -482,7 +482,7 @@ describe('Prune', function() {
 
   describe('postDeploy', function() {
 
-    it('should prune functions if automatic is option is configured', function() {
+    it('should prune functions if automatic option is configured', function() {
 
       const custom = {
         prune: { automatic: true, number: 10 }
@@ -496,6 +496,36 @@ describe('Prune', function() {
         sinon.assert.calledOnce(plugin.prune);
       });
     });
+
+    it('should prune all functions if automatic option is configured and number is 0', function() {
+
+      const custom = {
+        prune: { automatic: true, number: 0 }
+      };
+      const serverlessStub = createMockServerless([], custom);
+
+      const plugin = new PrunePlugin(serverlessStub, {});
+      sinon.spy(plugin, 'prune');
+
+      return plugin.postDeploy().then(() => {
+        sinon.assert.calledOnce(plugin.prune);
+      });
+    });    
+
+    it('should not prune functions if automatic option is configured without a number', function() {
+
+      const custom = {
+        prune: { automatic: true }
+      };
+      const serverlessStub = createMockServerless([], custom);
+
+      const plugin = new PrunePlugin(serverlessStub, {});
+      sinon.spy(plugin, 'prune');
+
+      return plugin.postDeploy().then(() => {
+        sinon.assert.notCalled(plugin.prune);
+      });
+    });    
 
     it('should not prune functions if noDeploy flag is set', function() {
 


### PR DESCRIPTION
Accept number: 0 as valid configuration when running automatically. 
This makes it possible to "clean" existing stacks that have versioning disabled (but had it enabled in the past).