### PR TITLE
Skip non-versioned functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,8 @@ class Prune {
   }
 
   pruneFunctions() {
-    const selectedFunctions = this.options.function ? [this.options.function] : this.serverless.service.getAllFunctions();
+    const selectedFunctions = this.options.function ? [this.options.function] :
+      (this.serverless.service.provider.versionFunctions === false ? this.serverless.service.getAllFunctions().filter(key => this.serverless.service.getFunction(key).provisionedConcurrency) : this.serverless.service.getAllFunctions());
     const functionNames = selectedFunctions.map(key => this.serverless.service.getFunction(key).name);
 
     this.createProgress(


### PR DESCRIPTION
Services may turn off versioning for the entire service.  
If turned off on the service, and using Provisioned Concurrency for some functions, Serverless will automatically versioned said functions as it requires to be able to set an alias and PC it.  

This change helps when having large services with lots of functions where most of them don't require cleanup and the vast amount of which gets loads of rate limits when using this plugin.