### PR TITLE
chore: modify constraints to work on serverless v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "sinon": "^12.0.1"
       },
       "peerDependencies": {
-        "serverless": "1 || 2 || 3"
+        "serverless": "1.x || 2.x || 3.x || 4.x"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "sinon": "^12.0.1"
   },
   "peerDependencies": {
-    "serverless": "1 || 2 || 3"
+    "serverless": "1.x || 2.x || 3.x || 4.x"
   }
 }


### PR DESCRIPTION
## Description

As Serverless V4 has beed released some time a go, we have been plannig to upgrade services that uses this plugin, but his constraints do not allow to use it with it.

This modification just affect the constraints not other functionallity:|

## Test evidence

![Screenshot 2024-08-21 at 12 22 54 p m](https://github.com/user-attachments/assets/ce785afd-b1dc-4a15-8d4e-4b16c8f78747)
