### PR TITLE
fix: support osls v4 (removed provider.request v2 surface)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,31 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const { LambdaClient } = require('@aws-sdk/client-lambda');
+
+/**
+ * Invoke a Lambda AWS API method in a framework-aware way.
+ * osls v4 removed provider.request() (throws AWS_SDK_V2_SURFACE_REMOVED);
+ * there a LambdaClient is built from provider.getAwsSdkV3Config() and the
+ * matching <Method>Command is sent. On serverless v3 the original
+ * provider.request() surface is kept as-is. LambdaClients are cached per
+ * provider via a WeakMap.
+ */
+const lambdaClientPromises = new WeakMap();
+function lambdaRequest(provider, action, params) {
+  if (typeof provider.getAwsSdkV3Config !== 'function') {
+    return provider.request('Lambda', action, params);
+  }
+  let clientPromise = lambdaClientPromises.get(provider);
+  if (!clientPromise) {
+    clientPromise = provider.getAwsSdkV3Config().then((cfg) => new LambdaClient(cfg));
+    lambdaClientPromises.set(provider, clientPromise);
+  }
+  return clientPromise.then((client) => {
+    const { [`${action}Command`]: Command } = require('@aws-sdk/client-lambda');
+    return client.send(new Command(params));
+  });
+}
 
 class Prune {
   constructor(serverless, options, { log, progress } = {}) {
@@ -226,7 +251,7 @@ class Prune {
       };
 
       return BbPromise.resolve()
-        .then(() => this.provider.request('Lambda', 'deleteLayerVersion', params))
+        .then(() => lambdaRequest(this.provider,'deleteLayerVersion', params))
         .catch(e => {
           throw e;
         });
@@ -243,7 +268,7 @@ class Prune {
       };
 
       return BbPromise.resolve()
-        .then(() => this.provider.request('Lambda', 'deleteFunction', params))
+        .then(() => lambdaRequest(this.provider,'deleteFunction', params))
         .catch(e => {
           //ignore if trying to delete replicated lambda edge function
           if (e.providerError && e.providerError.statusCode === 400
@@ -303,14 +328,14 @@ class Prune {
       Array.prototype.push.apply(results, responseMapping(response));
 
       if (response.NextMarker) {
-        return this.provider.request('Lambda', action, Object.assign({}, params, { Marker: response.NextMarker }))
+        return lambdaRequest(this.provider,action, Object.assign({}, params, { Marker: response.NextMarker }))
           .then(responseHandler);
       } else {
         return BbPromise.resolve(results);
       }
     };
 
-    return this.provider.request('Lambda', action, params)
+    return lambdaRequest(this.provider,action, params)
       .then(responseHandler);
   }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {
+    "@aws-sdk/client-lambda": "^3.1079.0",
     "bluebird": "^3.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Context

osls v4 (open-source serverless framework fork) removed the AWS SDK v2 internal surfaces. `provider.request()` now throws `AWS_SDK_V2_SURFACE_REMOVED`:

https://github.com/oss-serverless/osls/blob/4.x/docs/guides/upgrading-to-v4.md#aws-sdk-v2-removed-plugin-authors

This plugin calls `this.provider.request('Lambda', ...)` for listing/deleting functions and layers, so it crashes on osls v4.

## Change

Route Lambda calls through `lambdaRequest(provider, action, params)`:

- **osls v4** (`getAwsSdkV3Config` present): build a cached `LambdaClient` from `provider.getAwsSdkV3Config()` and send the matching `<Action>Command` (clients cached per provider via `WeakMap`).
- **serverless v3**: unchanged — still calls `provider.request()`.

`@aws-sdk/client-lambda` is declared as a runtime dependency.